### PR TITLE
fix:两个问题，一个是组件值属性绑定的变量变换为空或者空字符串时这个画布不会刷新，第二个是后续加的新图形变换颜色之后只会变成黑色

### DIFF
--- a/packages/cw/cw_drawing_image_view_library/components/cw-drawing-image-view/index.vue
+++ b/packages/cw/cw_drawing_image_view_library/components/cw-drawing-image-view/index.vue
@@ -864,15 +864,28 @@ export default {
         canvas.renderAll()
       },
       handleSetColor(data){
-        const objects =  this.selectedObj.getObjects()
-        objects.forEach(item=>{
-          if(item.type == "rect" ){
-              item.set("fill",data.bgColor)
-          }else{
+        if(this.selectedList.length===1){
+           if(this.selectedList[0].type === 'group'){
+           const objects =  this.selectedObj.getObjects()
+            objects.forEach(item=>{
+              setColor(item,data)
+            })
+           }else{
+             setColor(this.selectedList[0],data)
+           }
+        }else{
+          this.selectedList.forEach(item=>{
+            setColor(item,data)
+          })
+        }
+        
+        function setColor(item,data){
+        if(item.type == "textbox" ){
               item.set("fill",data.textColor)
+          }else{
+             item.set("fill",data.bgColor)
           }
-        })
-        console.log(objects);
+        }
         canvas.renderAll()
       },
       getCanvasPointer(ev){

--- a/packages/cw/cw_drawing_image_view_library/package.json
+++ b/packages/cw/cw_drawing_image_view_library/package.json
@@ -2,7 +2,7 @@
   "name": "cw_drawing_view_library",
   "title": "平面绘制依赖库",
   "description": "可导入一个背景，在上面实现小部件的拖拽",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "./index.js",
   "author": "",
   "repository": "",


### PR DESCRIPTION
## cw_drawing_image_view_library

## 1.1.1

Associated Task: [#282014](https://projectmanage.netease-official.lcap.163yun.com/dashboard/TaskDetail?id=2820142194158336)

### 🐛Bug Fixes

- [de65196](https://github.com/vusion/cloud-ui-materials/commit/de651967b3a4ec52a6ab5183dc7418b3b4116b16) Thanks [xuguanjie](https://github.com/xuguanjie) ! - 两个问题，一个是组件值属性绑定的变量变换为空或者空字符串时这个画布不会刷新，第二个是后续加的新图形变换颜色之后只会变成黑色



